### PR TITLE
refs task #69507 [購入リクエスト本一覧]管理者が承認するボタンを追加

### DIFF
--- a/app/controllers/purchase_requests_controller.rb
+++ b/app/controllers/purchase_requests_controller.rb
@@ -33,12 +33,10 @@ class PurchaseRequestsController < ApplicationController
   end
 
   def update
-    respond_to do |format|
-      if @purchase_request.update(purchase_request_params)
-        format.html { redirect_to purchase_requests_path, notice: 'Purchase request was successfully updated.' }
-      else
-        format.html { render :index }
-      end
+    if @purchase_request.update(purchase_request_params)
+      redirect_to purchase_requests_path, notice: 'Purchase request was successfully updated.'
+    else
+      render :index
     end
   end
 

--- a/app/controllers/purchase_requests_controller.rb
+++ b/app/controllers/purchase_requests_controller.rb
@@ -35,11 +35,9 @@ class PurchaseRequestsController < ApplicationController
   def update
     respond_to do |format|
       if @purchase_request.update(purchase_request_params)
-        format.html { redirect_to @purchase_request, notice: 'Purchase request was successfully updated.' }
-        format.json { render :show, status: :ok, location: @purchase_request }
+        format.html { redirect_to purchase_requests_path, notice: 'Purchase request was successfully updated.' }
       else
-        format.html { render :edit }
-        format.json { render json: @purchase_request.errors, status: :unprocessable_entity }
+        format.html { render :index }
       end
     end
   end

--- a/app/models/m/book.rb
+++ b/app/models/m/book.rb
@@ -7,8 +7,10 @@ class M::Book < ActiveRecord::Base
   validates :name, presence: true
   validates :isbn, presence: true, uniqueness: true
 
-  scope :refer_to_m_book, -> isbn do
-    find_or_create_by isbn: isbn
+  class << self
+    def refer_to_m_book isbn
+      find_or_create_by isbn: isbn
+    end
   end
 
   def requested_by? user

--- a/app/models/m/book.rb
+++ b/app/models/m/book.rb
@@ -7,8 +7,8 @@ class M::Book < ActiveRecord::Base
   validates :name, presence: true
   validates :isbn, presence: true, uniqueness: true
 
-  scope :refer_to_m_book, ->name, isbn do
-    find_or_create_by name: name, isbn: isbn
+  scope :refer_to_m_book, -> isbn do
+    find_or_create_by isbn: isbn
   end
 
   def requested_by? user

--- a/app/models/purchase_request.rb
+++ b/app/models/purchase_request.rb
@@ -2,13 +2,12 @@ class PurchaseRequest < ActiveRecord::Base
   UPDATABLE_ATTRS = %i(m_book_id user_id state).concat M::Book::UPDATABLE_ATTRS
   attr_accessor :name, :isbn
 
-  enum state: {waiting: 0, accepted: 1, nonaccepted: 2}
+  enum state: { waiting: 0, accepted: 1, nonaccepted: 2 }
 
   belongs_to :m_book, class_name: M::Book.name
   belongs_to :user
 
-  before_validation :fetch_book
-  after_update :create_product_if_accepted
+  before_validation :fetch_book, on: :create
 
   validates :user_id, :m_book_id, presence: true
 
@@ -16,17 +15,8 @@ class PurchaseRequest < ActiveRecord::Base
     where user_id: user_id, m_book_id: m_book_id
   end
 
-  def state_is? _state
-    state.intern == _state.intern
-  end
-
   private
   def fetch_book
-    self.m_book = M::Book.refer_to_m_book name, isbn
-  end
-
-  def create_product_if_accepted
-    return unless self.state_is? :accepted
-    Product.create m_book_id: m_book_id
+    self.m_book = M::Book.refer_to_m_book isbn
   end
 end

--- a/app/views/purchase_requests/_state_form.html.erb
+++ b/app/views/purchase_requests/_state_form.html.erb
@@ -1,0 +1,6 @@
+<td>
+  <%= link_to "承認", purchase_request_path(purchase_request, purchase_request: { state: "accepted" }), method: :patch, class: "btn btn-success", disabled: purchase_request.accepted? %>
+</td>
+<td>
+  <%= link_to "保留", purchase_request_path(purchase_request, purchase_request: { state: "nonaccepted" }), method: :patch, class: "btn btn-danger", disabled: purchase_request.nonaccepted? %>
+</td>

--- a/app/views/purchase_requests/index.html.erb
+++ b/app/views/purchase_requests/index.html.erb
@@ -11,7 +11,9 @@
       <th>申請者</th>
       <th>画像</th>
       <th>ISBNコード</th>
-      <th>タイトル</th>
+      <th class="col-md-2">タイトル</th>
+      <th>承認ステータス</th>
+      <% if current_user.admin? %><th colspan="2"></th><% end %>
     </tr>
   </thead>
 
@@ -24,6 +26,14 @@
         <td><%= link_to image_tag(purchase_request.m_book.book_image_path), "http://www.amazon.co.jp/dp/" + purchase_request.m_book.isbn, target: ["_blank"] %></td>
         <td><%= purchase_request.m_book.isbn %></td>
         <td><%= purchase_request.m_book.name %></td>
+        <% if purchase_request.waiting? %>
+          <td>リクエスト中</td>
+        <% elsif purchase_request.accepted? %>
+          <td>承認済み</td>
+        <% else %>
+          <td>保留</td>
+        <% end %>
+        <%= render partial: "state_form", locals: { purchase_request: purchase_request } if current_user.admin? %>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
- 「承認ステータス」のコラムをを追加
- 「承認」「保留」ボタンを追加（admin のみ表示）
- 必要のないメソッドを削除
- fetch_book メソッドが全てのバリデーションで働いていたので create のみに制限
